### PR TITLE
Update README.galaxy-brain.md

### DIFF
--- a/assets/steps/README.galaxy-brain.md
+++ b/assets/steps/README.galaxy-brain.md
@@ -9,11 +9,6 @@
 
 ## How to get Galaxy Brain GitHub achievement step by step :
 
-### 1. You need to go to the GitHub community address (https://github.com/community/community) . And select one of the feedback categories .
-
-<div align="center">
-<img width="400" src="../img/galaxy-brain/galaxy-step1.png" alt="galaxy-brain-step1.png">
-</div>
 
 ### 2. Now you need to find Unanswered Question's in any categories you want . and answer the questions.
 


### PR DESCRIPTION
Removed step 1 that instructs users to visit the GitHub's Community Discussions in order to earn badges since we've had some users visit the community seeking to earn achievements.

Note that these instructions are now out of date since Achievements are no longer available to earn in GitHub's community discussions. You can learn more about that decision here: https://github.com/orgs/community/discussions/106536.

Note that you may need to replace this with alternative instructions for your users. An alternative could be to create a feedback channel in your own Discussion community specifically for earning achievements and point users there: https://github.com/4xmen/Get-Github-Achievements/discussions.

Thanks!